### PR TITLE
Add specific gravity device class and units

### DIFF
--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -96,6 +96,9 @@ class SensorDeviceClass(BaseDeviceClass):
     # signal strength (dB/dBm)
     SIGNAL_STRENGTH = "signal_strength"
 
+    # specific gravity
+    SPECIFIC_GRAVITY = "specific_gravity"
+
     # Amount of SO2 (µg/m³)
     SULPHUR_DIOXIDE = "sulphur_dioxide"
 

--- a/src/sensor_state_data/units.py
+++ b/src/sensor_state_data/units.py
@@ -192,3 +192,6 @@ class Units(StrEnum):
     DATA_RATE_KIBIBYTES_PER_SECOND: Final = "KiB/s"
     DATA_RATE_MEBIBYTES_PER_SECOND: Final = "MiB/s"
     DATA_RATE_GIBIBYTES_PER_SECOND: Final = "GiB/s"
+
+    # Specific gravity units
+    SPECIFIC_GRAVITY = "SG"


### PR DESCRIPTION
This is necessary for the Tilt BLE sensor [here](https://github.com/Bluetooth-Devices/tilt-ble/pull/1). Still have an open question about the units since this sensor is truly unitless. I made it just "SG" for now in case we need to just fill in something.