### PR TITLE
feat: add binary sensor device class

### DIFF
--- a/src/sensor_state_data/binary_sensor/device_class.py
+++ b/src/sensor_state_data/binary_sensor/device_class.py
@@ -12,9 +12,6 @@ class BinarySensorDeviceClass(BaseDeviceClass):
     # On means charging, Off means not charging
     BATTERY_CHARGING = "battery_charging"
 
-    # On means On, Off means Off
-    BINARY = "binary"
-
     # On means carbon monoxide detected, Off means no carbon monoxide (clear)
     CO = "carbon_monoxide"
 
@@ -32,6 +29,9 @@ class BinarySensorDeviceClass(BaseDeviceClass):
 
     # On means gas detected, Off means no gas (clear)
     GAS = "gas"
+
+    # On means On, Off means Off
+    GENERIC = "generic"
 
     # On means hot, Off means normal
     HEAT = "heat"

--- a/src/sensor_state_data/binary_sensor/device_class.py
+++ b/src/sensor_state_data/binary_sensor/device_class.py
@@ -12,6 +12,9 @@ class BinarySensorDeviceClass(BaseDeviceClass):
     # On means charging, Off means not charging
     BATTERY_CHARGING = "battery_charging"
 
+    # On means On, Off means Off
+    BINARY = "binary"
+
     # On means carbon monoxide detected, Off means no carbon monoxide (clear)
     CO = "carbon_monoxide"
 


### PR DESCRIPTION
I want to add a Binary Sensor (without device class) to BTHome. This PR adds it to the BinarySensorDeviceClass as "binary" device class, similar as we did for sensors with a device class that aren't available in HA (which will be translated to a device class None in bthome_ble)