### PR TITLE
feat: add dimmer switch and button

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -8,33 +8,33 @@ from .units import Units
 class SensorLibrary:
     """A library of sensor common descriptions."""
 
-    TEMPERATURE__CELSIUS = BaseSensorDescription(
-        device_class=SensorDeviceClass.TEMPERATURE,
-        native_unit_of_measurement=Units.TEMP_CELSIUS,
-    )
-    PRESSURE__MBAR = BaseSensorDescription(
-        device_class=SensorDeviceClass.PRESSURE,
-        native_unit_of_measurement=Units.PRESSURE_MBAR,
-    )
-    HUMIDITY__PERCENTAGE = BaseSensorDescription(
-        device_class=SensorDeviceClass.HUMIDITY,
+    BATTERY__PERCENTAGE = BaseSensorDescription(
+        device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=Units.PERCENTAGE,
     )
-    LIGHT__LIGHT_LUX = BaseSensorDescription(
-        device_class=SensorDeviceClass.ILLUMINANCE,
-        native_unit_of_measurement=Units.LIGHT_LUX,
+    BUTTON__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.BUTTON,
+        native_unit_of_measurement=None,
     )
-    VOLTAGE__ELECTRIC_POTENTIAL_VOLT = BaseSensorDescription(
-        device_class=SensorDeviceClass.VOLTAGE,
-        native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+    COUNT__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.COUNT,
+        native_unit_of_measurement=None,
+    )
+    CO2__CONCENTRATION_PARTS_PER_MILLION = BaseSensorDescription(
+        device_class=SensorDeviceClass.CO2,
+        native_unit_of_measurement=Units.CONCENTRATION_PARTS_PER_MILLION,
     )
     CURRENT__POWER_VOLT_AMPERE = BaseSensorDescription(
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=Units.POWER_VOLT_AMPERE,
     )
-    POWER__POWER_WATT = BaseSensorDescription(
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=Units.POWER_WATT,
+    DEW_POINT__TEMP_CELSIUS = BaseSensorDescription(
+        device_class=SensorDeviceClass.DEW_POINT,
+        native_unit_of_measurement=Units.TEMP_CELSIUS,
+    )
+    DIMMER__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.DIMMER,
+        native_unit_of_measurement=None,
     )
     ENERGY__ENERGY_KILO_WATT_HOUR = BaseSensorDescription(
         device_class=SensorDeviceClass.ENERGY,
@@ -44,8 +44,32 @@ class SensorLibrary:
         device_class=SensorDeviceClass.GAS,
         native_unit_of_measurement=Units.VOLUME_CUBIC_METERS,
     )
-    BATTERY__PERCENTAGE = BaseSensorDescription(
-        device_class=SensorDeviceClass.BATTERY,
+    HUMIDITY__PERCENTAGE = BaseSensorDescription(
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=Units.PERCENTAGE,
+    )
+    KEG_SIZE__VOLUME_LITERS = BaseSensorDescription(
+        device_class=SensorDeviceClass.KEG_SIZE,
+        native_unit_of_measurement=Units.VOLUME_LITERS,
+    )
+    KEG_TYPE__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.KEG_TYPE,
+        native_unit_of_measurement=None,
+    )
+    LIGHT__LIGHT_LUX = BaseSensorDescription(
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        native_unit_of_measurement=Units.LIGHT_LUX,
+    )
+    MASS__MASS_KILOGRAMS = BaseSensorDescription(
+        device_class=SensorDeviceClass.MASS,
+        native_unit_of_measurement=Units.MASS_KILOGRAMS,
+    )
+    MASS__MASS_POUNDS = BaseSensorDescription(
+        device_class=SensorDeviceClass.MASS,
+        native_unit_of_measurement=Units.MASS_POUNDS,
+    )
+    MOISTURE__PERCENTAGE = BaseSensorDescription(
+        device_class=SensorDeviceClass.MOISTURE,
         native_unit_of_measurement=Units.PERCENTAGE,
     )
     PM1__CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = BaseSensorDescription(
@@ -60,9 +84,33 @@ class SensorLibrary:
         device_class=SensorDeviceClass.PM25,
         native_unit_of_measurement=Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     )
-    CO2__CONCENTRATION_PARTS_PER_MILLION = BaseSensorDescription(
-        device_class=SensorDeviceClass.CO2,
-        native_unit_of_measurement=Units.CONCENTRATION_PARTS_PER_MILLION,
+    PORT_COUNT__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.PORT_COUNT,
+        native_unit_of_measurement=None,
+    )
+    PORT_NAME__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.PORT_NAME,
+        native_unit_of_measurement=None,
+    )
+    PORT_STATE__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.PORT_STATE,
+        native_unit_of_measurement=None,
+    )
+    POWER__POWER_WATT = BaseSensorDescription(
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=Units.POWER_WATT,
+    )
+    PRESSURE__MBAR = BaseSensorDescription(
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement=Units.PRESSURE_MBAR,
+    )
+    SWITCH__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.SWITCH,
+        native_unit_of_measurement=None,
+    )
+    TEMPERATURE__CELSIUS = BaseSensorDescription(
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=Units.TEMP_CELSIUS,
     )
     VOLATILE_ORGANIC_COMPOUNDS__CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = (
         BaseSensorDescription(
@@ -70,51 +118,15 @@ class SensorLibrary:
             native_unit_of_measurement=Units.CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         )
     )
-    MASS__MASS_KILOGRAMS = BaseSensorDescription(
-        device_class=SensorDeviceClass.MASS,
-        native_unit_of_measurement=Units.MASS_KILOGRAMS,
-    )
-    MASS__MASS_POUNDS = BaseSensorDescription(
-        device_class=SensorDeviceClass.MASS,
-        native_unit_of_measurement=Units.MASS_POUNDS,
-    )
-    MOISTURE__PERCENTAGE = BaseSensorDescription(
-        device_class=SensorDeviceClass.MOISTURE,
-        native_unit_of_measurement=Units.PERCENTAGE,
-    )
-    DEW_POINT__TEMP_CELSIUS = BaseSensorDescription(
-        device_class=SensorDeviceClass.DEW_POINT,
-        native_unit_of_measurement=Units.TEMP_CELSIUS,
-    )
-    COUNT__NONE = BaseSensorDescription(
-        device_class=SensorDeviceClass.COUNT,
-        native_unit_of_measurement=None,
-    )
-    KEG_SIZE__VOLUME_LITERS = BaseSensorDescription(
-        device_class=SensorDeviceClass.KEG_SIZE,
-        native_unit_of_measurement=Units.VOLUME_LITERS,
-    )
-    KEG_TYPE__NONE = BaseSensorDescription(
-        device_class=SensorDeviceClass.KEG_TYPE,
-        native_unit_of_measurement=None,
-    )
-    PORT_COUNT__NONE = BaseSensorDescription(
-        device_class=SensorDeviceClass.PORT_COUNT,
-        native_unit_of_measurement=None,
-    )
-    PORT_STATE__NONE = BaseSensorDescription(
-        device_class=SensorDeviceClass.PORT_STATE,
-        native_unit_of_measurement=None,
-    )
-    PORT_NAME__NONE = BaseSensorDescription(
-        device_class=SensorDeviceClass.PORT_NAME,
-        native_unit_of_measurement=None,
-    )
-    VOLUME_START__VOLUME_LITERS = BaseSensorDescription(
-        device_class=SensorDeviceClass.VOLUME_START,
-        native_unit_of_measurement=Units.VOLUME_LITERS,
+    VOLTAGE__ELECTRIC_POTENTIAL_VOLT = BaseSensorDescription(
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
     )
     VOLUME_DISPENSED__VOLUME_LITERS = BaseSensorDescription(
         device_class=SensorDeviceClass.VOLUME_DISPENSED,
+        native_unit_of_measurement=Units.VOLUME_LITERS,
+    )
+    VOLUME_START__VOLUME_LITERS = BaseSensorDescription(
+        device_class=SensorDeviceClass.VOLUME_START,
         native_unit_of_measurement=Units.VOLUME_LITERS,
     )

--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -15,6 +15,9 @@ class SensorDeviceClass(BaseDeviceClass):
     # % of battery that is left
     BATTERY = "battery"
 
+    # button (no unit)
+    BUTTON = "button"
+
     # ppm (parts per million) Carbon Monoxide gas concentration
     CO = "carbon_monoxide"
 
@@ -32,6 +35,9 @@ class SensorDeviceClass(BaseDeviceClass):
 
     # dew point (°C/F)
     DEW_POINT = "dew_point"
+
+    # dimmer (no unit)
+    DIMMER = "dimmer"
 
     # fixed duration (TIME_DAYS, TIME_HOURS, TIME_MINUTES, TIME_SECONDS)
     DURATION = "duration"
@@ -116,6 +122,9 @@ class SensorDeviceClass(BaseDeviceClass):
 
     # Amount of SO2 (µg/m³)
     SULPHUR_DIOXIDE = "sulphur_dioxide"
+
+    # switch (no unit)
+    SWITCH = "switch"
 
     # temperature (°C/F)
     TEMPERATURE = "temperature"


### PR DESCRIPTION
Adding sensors Dimmer, Switch, and Button, which are needed for BTHome and xiaomi-ble

Dimmer = Light dimmer (xiaomi uses this for states/events like "rotate left, 3 steps", rotate right, 8 steps")
Switch = rocker switch (with states/events like "single click, double click, long click, etc)
Button = Button (with states/events like "button pressed")

Also made the SensorLibrary in alphabetical order. 