### PR TITLE
fix: combine event data in str or dict

### DIFF
--- a/src/sensor_state_data/data.py
+++ b/src/sensor_state_data/data.py
@@ -289,7 +289,7 @@ class SensorData:
     def fire_event(
         self,
         key: str,
-        event_data: str | dict[str, str | int | float],
+        event_data: dict[str, str | int | float | None],
         name: str | None = None,
         device_id: str | None = None,
     ) -> None:

--- a/src/sensor_state_data/data.py
+++ b/src/sensor_state_data/data.py
@@ -289,8 +289,7 @@ class SensorData:
     def fire_event(
         self,
         key: str,
-        event_type: str,
-        event_subtype: str | None = None,
+        event_data: str | dict[str, str | int | float],
         name: str | None = None,
         device_id: str | None = None,
     ) -> None:
@@ -299,6 +298,5 @@ class SensorData:
         self._events_updates[device_key] = Event(
             name=name or self._get_key_name(key, device_id),
             device_key=device_key,
-            event_type=event_type,
-            event_subtype=event_subtype,
+            event_data=event_data,
         )

--- a/src/sensor_state_data/data.py
+++ b/src/sensor_state_data/data.py
@@ -289,7 +289,8 @@ class SensorData:
     def fire_event(
         self,
         key: str,
-        event_data: dict[str, str | int | float | None],
+        event_type: str,
+        event_properties: dict[str, str | int | float | None] | None = None,
         name: str | None = None,
         device_id: str | None = None,
     ) -> None:
@@ -298,5 +299,6 @@ class SensorData:
         self._events_updates[device_key] = Event(
             name=name or self._get_key_name(key, device_id),
             device_key=device_key,
-            event_data=event_data,
+            event_type=event_type,
+            event_properties=event_properties,
         )

--- a/src/sensor_state_data/value.py
+++ b/src/sensor_state_data/value.py
@@ -32,4 +32,5 @@ class BinarySensorValue(BaseValue):
 class Event(BaseValue):
     """A class that describes device events."""
 
-    event_data: dict[str, str | int | float | None]
+    event_type: str
+    event_properties: dict[str, str | int | float | None] | None

--- a/src/sensor_state_data/value.py
+++ b/src/sensor_state_data/value.py
@@ -32,4 +32,4 @@ class BinarySensorValue(BaseValue):
 class Event(BaseValue):
     """A class that describes device events."""
 
-    event_data: str | dict[str, str | int | float]
+    event_data: dict[str, str | int | float | None]

--- a/src/sensor_state_data/value.py
+++ b/src/sensor_state_data/value.py
@@ -32,5 +32,4 @@ class BinarySensorValue(BaseValue):
 class Event(BaseValue):
     """A class that describes device events."""
 
-    event_type: str
-    event_subtype: str | None
+    event_data: str | dict[str, str | int | float]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -178,8 +178,7 @@ def test_event():
         def _start_update(self, data: Any) -> None:
             self.fire_event(
                 key="dimmer",
-                event_type="rotate_left",
-                event_subtype="3",
+                event_data={"rotate_left": 3},
                 device_id="living_room",
             )
 
@@ -197,8 +196,7 @@ def test_event():
             DeviceKey(key="dimmer", device_id="living_room"): Event(
                 device_key=DeviceKey(key="dimmer", device_id="living_room"),
                 name="Dimmer",
-                event_type="rotate_left",
-                event_subtype="3",
+                event_data={"rotate_left": 3},
             )
         },
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -178,7 +178,8 @@ def test_event():
         def _start_update(self, data: Any) -> None:
             self.fire_event(
                 key="dimmer",
-                event_data={"rotate_left": 3},
+                event_type="rotate_left",
+                event_properties={"steps": 3},
                 device_id="living_room",
             )
 
@@ -196,7 +197,8 @@ def test_event():
             DeviceKey(key="dimmer", device_id="living_room"): Event(
                 device_key=DeviceKey(key="dimmer", device_id="living_room"),
                 name="Dimmer",
-                event_data={"rotate_left": 3},
+                event_type="rotate_left",
+                event_properties={"steps": 3},
             )
         },
     )


### PR DESCRIPTION
Combining `event_type` and `event_subtype` into `event_data`. 

`event_data` can be a string (e.g. `"toggle"`) or a dictionary (e.g. `{"rotate left": 3}`)
