### PR TITLE
fix: volt ampere should be ampere

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -20,9 +20,9 @@ class SensorLibrary:
         device_class=SensorDeviceClass.CO2,
         native_unit_of_measurement=Units.CONCENTRATION_PARTS_PER_MILLION,
     )
-    CURRENT__POWER_VOLT_AMPERE = BaseSensorDescription(
+    CURRENT__ELECTRIC_CURRENT_AMPERE = BaseSensorDescription(
         device_class=SensorDeviceClass.CURRENT,
-        native_unit_of_measurement=Units.POWER_VOLT_AMPERE,
+        native_unit_of_measurement=Units.ELECTRIC_CURRENT_AMPERE,
     )
     DEW_POINT__TEMP_CELSIUS = BaseSensorDescription(
         device_class=SensorDeviceClass.DEW_POINT,


### PR DESCRIPTION
Small fix, unit of measurement of current should be A (Ampere) not VA (Volt Ampere). My mistake. 