### PR TITLE
feat: change time to duration and UV index

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -36,6 +36,10 @@ class SensorLibrary:
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=Units.LENGTH_MILLIMETERS,
     )
+    DURATION__TIME_SECONDS = BaseSensorDescription(
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=Units.TIME_SECONDS,
+    )
     ENERGY__ENERGY_KILO_WATT_HOUR = BaseSensorDescription(
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=Units.ENERGY_KILO_WATT_HOUR,
@@ -116,9 +120,9 @@ class SensorLibrary:
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=Units.TEMP_CELSIUS,
     )
-    DURATION__TIME_SECONDS = BaseSensorDescription(
-        device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=Units.TIME_SECONDS,
+    UV_INDEX__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.UV_INDEX,
+        native_unit_of_measurement=None,
     )
     VOLATILE_ORGANIC_COMPOUNDS__CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = (
         BaseSensorDescription(

--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -116,8 +116,8 @@ class SensorLibrary:
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=Units.TEMP_CELSIUS,
     )
-    TIME__TIME_SECONDS = BaseSensorDescription(
-        device_class=SensorDeviceClass.TIME,
+    DURATION__TIME_SECONDS = BaseSensorDescription(
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=Units.TIME_SECONDS,
     )
     VOLATILE_ORGANIC_COMPOUNDS__CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = (

--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -135,6 +135,9 @@ class SensorDeviceClass(BaseDeviceClass):
     # timestamp (ISO8601)
     TIMESTAMP = "timestamp"
 
+    # UV index (no unit)
+    UV_INDEX = "uv_index"
+
     # Amount of VOC (µg/m³)
     VOLATILE_ORGANIC_COMPOUNDS = "volatile_organic_compounds"
 


### PR DESCRIPTION
Time in seconds (`TIME__TIME_SECONDS`) should be Duration (`DURATION__TIME_SECONDS`) (HA also uses device class duration. 

TIME__TIME_SECONDS isn't used yet by any integration yet, I think, as I added it in the last PR (except BTHome, but I will take care of that).

Added UV index as sensor type 