### PR TITLE
Add current flow support

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -28,6 +28,10 @@ class SensorLibrary:
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=Units.ELECTRIC_CURRENT_AMPERE,
     )
+    CURRENT_FLOW__ELECTRIC_CURRENT_FLOW_AMPERE_HOUR = BaseSensorDescription(
+        device_class=SensorDeviceClass.CURRENT_FLOW,
+        native_unit_of_measurement=Units.ELECTRIC_CURRENT_FLOW_AMPERE_HOUR,
+    )
     DEW_POINT__TEMP_CELSIUS = BaseSensorDescription(
         device_class=SensorDeviceClass.DEW_POINT,
         native_unit_of_measurement=Units.TEMP_CELSIUS,

--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -30,6 +30,9 @@ class SensorDeviceClass(BaseDeviceClass):
     # current (A)
     CURRENT = "current"
 
+    # current flow (Ah)
+    CURRENT_FLOW = "current_flow"
+
     # date (ISO8601)
     DATE = "date"
 

--- a/src/sensor_state_data/units.py
+++ b/src/sensor_state_data/units.py
@@ -29,6 +29,10 @@ class Units(StrEnum):
     ELECTRIC_CURRENT_MILLIAMPERE: Final = "mA"
     ELECTRIC_CURRENT_AMPERE: Final = "A"
 
+    # Electric current flow units
+    ELECTRIC_CURRENT_FLOW_MILLIAMPERE_HOUR: Final = "mAh"
+    ELECTRIC_CURRENT_FLOW_AMPERE_HOUR: Final = "Ah"
+
     # Electric_potential units
     ELECTRIC_POTENTIAL_MILLIVOLT: Final = "mV"
     ELECTRIC_POTENTIAL_VOLT: Final = "V"


### PR DESCRIPTION
I have a new integration in the works (https://github.com/rajlaud/home-assistant/tree/victron-ble) that tracks a sensor that reports amp-hours. Would be great to add the appropriate units to sensor-state-data. The PR for the integration will add the units to Home Assistant core.