### PR TITLE
feat: add unit and class for specific gravity trend

### DIFF
--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -138,6 +138,9 @@ class SensorDeviceClass(BaseDeviceClass):
     # specific gravity
     SPECIFIC_GRAVITY = "specific_gravity"
 
+    # specific gravity trend
+    SPECIFIC_GRAVITY_TREND = "specific_gravity_trend"
+
     # speed (m/s)
     SPEED = "speed"
 

--- a/src/sensor_state_data/units.py
+++ b/src/sensor_state_data/units.py
@@ -201,3 +201,4 @@ class Units(StrEnum):
 
     # Specific gravity units
     SPECIFIC_GRAVITY = "SG"
+    SPECIFIC_GRAVITY_PER_DAY = "SG/d"


### PR DESCRIPTION
Payload parsed by the rapt_ble integration now includes trend of the specific gravity change (documented in https://github.com/sairon/rapt-ble/commit/7bef92fc3c1439a1d2c9180411aa695883c954a3). This PR adds new unit and device class for these metrics.