### PR TITLE
feat: add sensor description for pressure in hPa

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -128,6 +128,10 @@ class SensorLibrary:
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=Units.POWER_WATT,
     )
+    PRESSURE__HPA = BaseSensorDescription(
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement=Units.PRESSURE_HPA,
+    )
     PRESSURE__MBAR = BaseSensorDescription(
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=Units.PRESSURE_MBAR,


### PR DESCRIPTION
This is identical to the mbar equivalent but with hPa as the unit.