### PR TITLE
fix: remove unwanted scale sensors

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -100,18 +100,6 @@ class SensorLibrary:
         device_class=SensorDeviceClass.MASS_NON_STABILIZED,
         native_unit_of_measurement=Units.MASS_KILOGRAMS,
     )
-    MASS_NON_STABILIZED__MASS_POUNDS = BaseSensorDescription(
-        device_class=SensorDeviceClass.MASS_NON_STABILIZED,
-        native_unit_of_measurement=Units.MASS_POUNDS,
-    )
-    MASS_STABILIZED__MASS_KILOGRAMS = BaseSensorDescription(
-        device_class=SensorDeviceClass.MASS_STABILIZED,
-        native_unit_of_measurement=Units.MASS_KILOGRAMS,
-    )
-    MASS_STABILIZED__MASS_POUNDS = BaseSensorDescription(
-        device_class=SensorDeviceClass.MASS_STABILIZED,
-        native_unit_of_measurement=Units.MASS_POUNDS,
-    )
     PACKET_ID__NONE = BaseSensorDescription(
         device_class=SensorDeviceClass.PACKET_ID,
         native_unit_of_measurement=None,

--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -87,9 +87,6 @@ class SensorDeviceClass(BaseDeviceClass):
     # mass non-stabilized (kg/lbs)
     MASS_NON_STABILIZED = "mass_non_stabilized"
 
-    # mass stabilized (kg/lbs)
-    MASS_STABILIZED = "mass_stabilized"
-
     # Amount of money (currency)
     MONETARY = "monetary"
 


### PR DESCRIPTION
fix: remove unwanted scale sensors

As requested by @emontnemery in https://github.com/home-assistant/core/pull/96807, I'm going to forward MiScale data only in kg, and I will use the Mass sensor for stabilized mass/weight. So I only need the non-stabilized mass sensor type.

Although it is an breaking change, I don't think anyone has started to use these sensor types, so it should be safe to remove them. 
