### PR TITLE
Add data chanel data type

### DIFF
--- a/src/sensor_state_data/library.py
+++ b/src/sensor_state_data/library.py
@@ -16,6 +16,10 @@ class SensorLibrary:
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=Units.PERCENTAGE,
     )
+    CHANNEL__NONE = BaseSensorDescription(
+        device_class=SensorDeviceClass.CHANNEL,
+        native_unit_of_measurement=None,
+    )
     CONDUCTIVITY__CONDUCTIVITY = BaseSensorDescription(
         device_class=SensorDeviceClass.CONDUCTIVITY,
         native_unit_of_measurement=Units.CONDUCTIVITY,

--- a/src/sensor_state_data/sensor/device_class.py
+++ b/src/sensor_state_data/sensor/device_class.py
@@ -18,6 +18,9 @@ class SensorDeviceClass(BaseDeviceClass):
     # % of battery that is left
     BATTERY = "battery"
 
+    # Data channel (no unit)
+    CHANNEL = "channel"
+
     # ppm (parts per million) Carbon Monoxide gas concentration
     CO = "carbon_monoxide"
 


### PR DESCRIPTION
Add additional sensor metadata type - channel. It's usage will allow to send data for multiple arrays of identical sensors, while the new data type - channel would sign the actual data channel.